### PR TITLE
$db_table_prefix overridden

### DIFF
--- a/install/config.php
+++ b/install/config.php
@@ -66,6 +66,5 @@ $url = $hostname . $app_dir . '/';
 // $master_account: this is the user id of the master (root) account.
 // The root user cannot be deleted, and automatically has permissions to everything regardless of group membership.
 $master_account = 1;
-$db_table_prefix = 'uf_';
 
 session_start();


### PR DESCRIPTION
User configured $db_table_prefix specific in models/db-settings.php is overridden in install/config.php
