### PR TITLE
Remove debug console log for base site path

### DIFF
--- a/js/userfrosting.js
+++ b/js/userfrosting.js
@@ -43,7 +43,6 @@ function getSitePath() {
     scriptPath = script.getAttribute('src', -1);
 	
 	var basePath = scriptPath.substr(0, scriptPath.lastIndexOf( '/js' )+1 );
-	console.log("base site path is: " + basePath);
 	return basePath;
 }
 


### PR DESCRIPTION
Base site path note was turning up in console twice whenever page loaded (presumably the function is called twice when setting up the page).
Removed the console.log that prints site path.

No biggie, but was doing my head in!

Continued to use my installation after deleting this line and nothing exploded.