### PR TITLE
Bug 263 - Lost password email timestamp format fix

### DIFF
--- a/models/config.php
+++ b/models/config.php
@@ -75,7 +75,7 @@ $settings = fetchConfigParameters();
 $plugin_settings = fetchConfigParametersPlugins();
 
 //Set Settings
-$emailDate = date('dmy');
+$emailDate = date('F j, Y');
 $emailActivation = $settings['activation'];
 $can_register = $settings['can_register'];
 $websiteName = $settings['website_name'];


### PR DESCRIPTION
This is a fix for https://github.com/alexweissman/UserFrosting/issues/263

$emailDate in models/config.php was formatted incorrectly. 

    $emailDate = date('F j, Y');

Formats a date as MONTH DAY, YEAR (i.e. March 21, 2015)

So the email now reads:

![date-fix](https://cloud.githubusercontent.com/assets/726102/6767083/ef424644-cff6-11e4-9361-b47cd47317a8.PNG)
