### PR TITLE
Fix for bug 264 - lost password request error

### DIFF
--- a/api/user_reset_password.php
+++ b/api/user_reset_password.php
@@ -35,7 +35,7 @@ set_error_handler('logAllErrors');
 
 // Request method: GET or POST
 $ajax = null;
-if (isset($_POST)){
+if (count($_POST)){
     $ajax = checkRequestMode("post");
 } else {
     $ajax = checkRequestMode("get");


### PR DESCRIPTION
Fix for https://github.com/alexweissman/UserFrosting/issues/264.

isset() was the wrong function to use in user_reset_password.php because it always returns true for $_POST and $_GET regardless of whether they contain anything (probably because they are superglobals and thus always available).

count() will work - a URL of the form URL?parameter=value (i.e. http://website.com/api/user_reset_password.php?deny=1f479ccf06482862421e3e265176f4ed) will return 1 and thus work as expected:

	$ajax = null;
	 if (count($_POST)){
		$ajax = checkRequestMode("post");
	 } else {
		$ajax = checkRequestMode("get");
	 }