### PR TITLE
Refactor - multiple declarations of identical logAllErrors()

### DIFF
--- a/install/config.php
+++ b/install/config.php
@@ -29,15 +29,6 @@ THE SOFTWARE.
 
 */
 
-// Used to force backend scripts to log errors rather than print them as output
-function logAllErrors($errno, $errstr, $errfile, $errline, array $errcontext) {
-	ini_set("log_errors", 1);
-	ini_set("display_errors", 0);
-	
-    error_log("Error ($errno): $errstr in $errfile on line $errline");
-	throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
-}
-
 require_once("../models/db-settings.php");
 require_once("../models/class_validator.php");
 require_once("../models/password.php");

--- a/models/config.php
+++ b/models/config.php
@@ -29,15 +29,6 @@ THE SOFTWARE.
 
 */
 
-// Used to force backend scripts to log errors rather than print them as output
-function logAllErrors($errno, $errstr, $errfile, $errline, array $errcontext) {
-	ini_set("log_errors", 1);
-	ini_set("display_errors", 0);
-	
-    error_log("Error ($errno): $errstr in $errfile on line $errline");
-	throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
-}
-
 // This will stop the installer / upgrader from running as it normally would and should always be set to false
 // Options TRUE | FALSE bool
 $dev_env = FALSE;

--- a/models/error_functions.php
+++ b/models/error_functions.php
@@ -92,4 +92,13 @@ function checkRequestMode($mode){
 	}
 }
 
+// Used to force backend scripts to log errors rather than print them as output
+function logAllErrors($errno, $errstr, $errfile, $errline, array $errcontext) {
+	ini_set("log_errors", 1);
+	ini_set("display_errors", 0);
+	
+    error_log("Error ($errno): $errstr in $errfile on line $errline");
+	throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
+}
+
 ?>

--- a/upgrade/0.2.2.filechanges.php
+++ b/upgrade/0.2.2.filechanges.php
@@ -46,16 +46,6 @@
         <pre>
         <strong>/models/config.php</strong>
 
-        <strong><u>Find:</u></strong>
-
-            function logAllErrors($errno, $errstr, $errfile, $errline, array $errcontext) {
-            ini_set("log_errors", 1);
-            ini_set("display_errors", 0);
-
-            error_log("Error ($errno): $errstr in $errfile on line $errline");
-            throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
-            }
-
         <strong><u>Add after:</u></strong>
 
             // This will stop the installer / upgrader from running as it normally would and should always be set to false

--- a/upgrade/config.php
+++ b/upgrade/config.php
@@ -29,15 +29,6 @@ THE SOFTWARE.
 
 */
 
-// Used to force backend scripts to log errors rather than print them as output
-function logAllErrors($errno, $errstr, $errfile, $errline, array $errcontext) {
-	ini_set("log_errors", 1);
-	ini_set("display_errors", 0);
-	
-    error_log("Error ($errno): $errstr in $errfile on line $errline");
-	throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
-}
-
 require_once("../models/db-settings.php");
 require_once("../models/class_validator.php");
 require_once("../models/password.php");


### PR DESCRIPTION
There is now one copy of logAllErrors in error_functions.php instead of declaring it several times in different parts of the program. All files that declared logAllErrors already include a copy of error_functions.php.

Also, the logAllErrors() string has been removed from the upgrade instructions since it is no longer declared in config file.