### PR TITLE
fix footer overflow

### DIFF
--- a/userfrosting/templates/themes/default/components/footer.html
+++ b/userfrosting/templates/themes/default/components/footer.html
@@ -1,5 +1,5 @@
 <footer>
-  <div class="container">
+  <div class="container-fluid">
     <div class="row">
         <div class="col-sm-6 text-left">
             &copy; <a href="{{site.uri.public}}">{{site.site_title}}</a>, {{ "now"|date("Y") }}


### PR DESCRIPTION
Setting the footer's container to container-fluid will allow it to be small at a large resolution (such as when the sidebar takes some of the width).