### PR TITLE
Fix problem in `MySQLDatabase::connection()` method

### DIFF
--- a/nginx_vhost.conf
+++ b/nginx_vhost.conf
@@ -1,0 +1,43 @@
+
+# This file is an example vhost for nginx.
+# you may place this in a seperate file and include it, 
+# or you may place this directly withing the http block of the nginx.conf
+
+server {
+    listen 80;
+    
+    server_name example.com; //the name of your website
+    root /usr/share/nginx/html/userfrosting/public/; //path to the public directory of where you installed uf.
+    
+    location ~ \.(php)$ {
+        # prevent 0-day exploit attempt
+        try_files $uri = 404;
+        
+        # prevent recursive Local File Inclusion attempt
+        location ~ \..*/.*\.php$ {return 404;}
+        
+        # prevent arbitrary Remote File Inclusion attempt
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        
+        fastcgi_keep_conn on;
+        fastcgi_pass  127.0.0.1:9000;
+        fastcgi_index  index.php;
+        fastcgi_param  SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        include        fastcgi_params;
+    }
+    
+    
+    # optional cache some static files
+    location ~* .(png|gif|jpg|jpeg|ico|css|js|woff|ttf|otf|woff2|eot)$ {
+        include /etc/nginx/mime.types;
+        expires max;
+    }
+
+    # the magic
+    location / {
+        include /etc/nginx/mime.types;
+        index index.php;
+        try_files $request_uri $request_uri/ /index.php?$query_string; # try $uri against index.php, including querystring (GET parameters).
+    }
+
+}

--- a/userfrosting/models/mysql/MySqlDatabase.php
+++ b/userfrosting/models/mysql/MySqlDatabase.php
@@ -26,7 +26,7 @@ abstract class MySqlDatabase extends UFDatabase implements DatabaseInterface {
             $db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);       // Let this function throw a PDO exception if it cannot connect.
             return $db;
         } catch (\PDOException $e){
-            echo "We can't seem to connect to the database!  Please check your database credentials in config-userfrosting.php.";
+            die("We can't seem to connect to the database!  Please check your database credentials in config-userfrosting.php.");
             //throw new DatabaseInvalidException($e->getMessage(), $e->getStatus(), $e->getPrevious());
         }
     }


### PR DESCRIPTION
script should be halted here due to lack of db connection. this fixes the problem where it is not, and the error message gets swallowed. temporary workaround until we can get `DatabaseException` to control flow for these situations. closes #424 