### PR TITLE
Security Fix for Session Fixation - huntr.dev 

### DIFF
--- a/app/sprinkles/account/config/default.php
+++ b/app/sprinkles/account/config/default.php
@@ -162,7 +162,18 @@ return [
         'check_username_request' => null,
         'password_reset_request' => null,
         'registration_attempt'   => null,
-        'sign_in_attempt'        => null,
+        'sign_in_attempt'        => [
+            'method'   => 'ip',
+            'interval' => 3600,
+            'delays'   => [
+                4 => 5,
+                5 => 10,
+                6 => 20,
+                7 => 40,
+                8 => 80,
+                9 => 600,
+            ],
+        ],
         'verification_request'   => null,
     ],
 


### PR DESCRIPTION
https://huntr.dev/users/alromh87 has fixed the Session Fixation vulnerability 🔨. alromh87 has been awarded $25 for fixing the vulnerability through the huntr bug bounty program 💵. Think you could fix a vulnerability like this?
           
Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/UserFrosting/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/staging/bounties/packagist/userfrosting/userfrosting/2/vulnerability.json

### User Comments:

### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/2-packagist-userfrosting%2Fuserfrosting

### ⚙️ Description *

Persistent sessions are invalidated after password change.

### 💻 Technical Description *

Userfost uses `gbirke/rememberme` for persistent sessions so `cleanAllTriplets` is called via logout in `Authenticator` class after password change.

### 🐛 Proof of Concept (PoC) *

1. Setup UserFrosting and crate user
2. Login with new user from two different browsers enabling 'Keep me signed in'
3. Change password on one session
4. Persistent session on the other browser will still be valid

### 🔥 Proof of Fix (PoF) *

After fix persistent session will be invalidated and user will have to login again.

![userfrostingPWDPOF](https://user-images.githubusercontent.com/7505980/94018561-6ac08380-fdb9-11ea-8282-34548438a596.png)

### 👍 User Acceptance Testing (UAT)

Password can be changed normally