### PR TITLE
Security Fix for E-mail Verification Bypass - huntr.dev 

### DIFF
--- a/app/sprinkles/account/config/default.php
+++ b/app/sprinkles/account/config/default.php
@@ -162,7 +162,18 @@ return [
         'check_username_request' => null,
         'password_reset_request' => null,
         'registration_attempt'   => null,
-        'sign_in_attempt'        => null,
+        'sign_in_attempt'        => [
+            'method'   => 'ip',
+            'interval' => 3600,
+            'delays'   => [
+                4 => 5,
+                5 => 10,
+                6 => 20,
+                7 => 40,
+                8 => 80,
+                9 => 600,
+            ],
+        ],
         'verification_request'   => null,
     ],
 

--- a/app/sprinkles/account/locale/en_US/messages.php
+++ b/app/sprinkles/account/locale/en_US/messages.php
@@ -39,6 +39,7 @@ return [
             '@TRANSLATION'  => 'Account settings',
             'DESCRIPTION'   => 'Update your account settings, including email, name, and password.',
             'UPDATED'       => 'Account settings updated',
+            'NEW_EMAIL'     => 'A link to update your email has been sent to <strong>{{newEmail}}</strong>. Current email <strong>{{email}}</strong> will be used until you complete this step.',
         ],
 
         'TOOLS' => 'Account tools',

--- a/app/sprinkles/account/locale/es_ES/messages.php
+++ b/app/sprinkles/account/locale/es_ES/messages.php
@@ -39,6 +39,7 @@ return [
             '@TRANSLATION' => 'Configuraciones de la cuenta',
             'DESCRIPTION'  => 'Actualiza la configuración de su cuenta, incluido el correo electrónico, el nombre y la contraseña.',
             'UPDATED'      => 'Configuración de la cuenta actualizada',
+            'NEW_EMAIL'     => 'Se ha enviado un enlace para actualizar tu correo electrónico a <strong>{{newEmail}}</strong>. El correo electrónico actual <strong>{{email}}</strong> será utilizado hasta que este paso sea completado.',
         ],
 
         'TOOLS' => 'Herramientas de la cuenta',

--- a/app/sprinkles/account/src/Controller/AccountController.php
+++ b/app/sprinkles/account/src/Controller/AccountController.php
@@ -1286,7 +1286,7 @@ class AccountController extends SimpleController
                 $ms->addMessageTranslated('danger', 'EMAIL.IN_USE', $data);
                 $error = true;
             } elseif ($this->ci->config['site.registration.require_email_verification']) {
-                // If email verification is configured										         app/sprinkles/account/src/Account/Registration.php
+                // If email verification is configured
 
                 // Avoid setting email until verified
                 $data['newEmail'] = $data['email'];

--- a/app/sprinkles/account/src/Controller/AccountController.php
+++ b/app/sprinkles/account/src/Controller/AccountController.php
@@ -29,6 +29,7 @@ use UserFrosting\Sprinkle\Core\Util\Captcha;
 use UserFrosting\Support\Exception\BadRequestException;
 use UserFrosting\Support\Exception\ForbiddenException;
 use UserFrosting\Support\Exception\NotFoundException;
+use UserFrosting\Sprinkle\Account\Database\Models\Interfaces\UserInterface;
 
 /**
  * Controller class for /account/* URLs.  Handles account-related activities, including login, registration, password recovery, and account settings.
@@ -1277,10 +1278,26 @@ class AccountController extends SimpleController
         unset($data['passwordcheck']);
         unset($data['passwordc']);
 
-        // If new email was submitted, check that the email address is not in use
-        if (isset($data['email']) && $data['email'] != $currentUser->email && $classMapper->getClassMapping('user')::findUnique($data['email'], 'email')) {
-            $ms->addMessageTranslated('danger', 'EMAIL.IN_USE', $data);
-            $error = true;
+        // If new email was submitted
+        if (isset($data['email']) && $data['email'] != $currentUser->email) {
+
+            // Check that the email address is not in use
+            if ($classMapper->getClassMapping('user')::findUnique($data['email'], 'email')) {
+                $ms->addMessageTranslated('danger', 'EMAIL.IN_USE', $data);
+                $error = true;
+            } elseif ($this->ci->config['site.registration.require_email_verification']) {
+                // If email verification is configured										         app/sprinkles/account/src/Account/Registration.php
+
+                // Avoid setting email until verified
+                $data['newEmail'] = $data['email'];
+                unset($data['email']);
+
+                // Send verification email
+                $this->sendVerificationForNewEmail($currentUser, $data['newEmail']);
+
+                // Show verification message
+                $ms->addMessageTranslated('success', 'ACCOUNT.SETTINGS.NEW_EMAIL', $currentUser->toArray());
+            }
         }
 
         if ($error) {
@@ -1404,5 +1421,29 @@ class AccountController extends SimpleController
 
         // Forward to login page
         return $response->withRedirect($loginPage);
+    }
+
+    /**
+     * Send verification email for specified user on new email request.
+     *
+     * @param \UserFrosting\Sprinkle\Account\Database\Models\Interfaces\UserInterface $user The user to send the email for
+     * @param String $newEmail The requested new email
+     */
+    protected function sendVerificationForNewEmail(UserInterface $user, String $newEmail)
+    {
+        // Try to generate a new verification request
+        $verification = $this->ci->repoVerification->create($user, $this->ci->config['verification.timeout']);
+
+        // Create and send verification email
+        $message = new TwigMailMessage($this->ci->view, 'mail/verify-new-email.html.twig');
+
+        $message->from($this->ci->config['address_book.admin'])
+                ->addEmailRecipient(new EmailRecipient($newEmail, $user->full_name))
+                ->addParams([
+                    'user'  => $user,
+                    'token' => $verification->getToken(),
+                ]);
+
+        $this->ci->mailer->send($message);
     }
 }

--- a/app/sprinkles/account/src/Database/Migrations/v400/UsersTable.php
+++ b/app/sprinkles/account/src/Database/Migrations/v400/UsersTable.php
@@ -43,6 +43,7 @@ class UsersTable extends Migration
                 $table->boolean('flag_enabled')->default(1)->comment('Set to 1 if the user account is currently enabled, 0 otherwise.  Disabled accounts cannot be logged in to, but they retain all of their data and settings.');
                 $table->integer('last_activity_id')->unsigned()->nullable()->comment('The id of the last activity performed by this user.');
                 $table->string('password', 255);
+                $table->string('newEmail', 254)->default('');
                 $table->softDeletes();
                 $table->timestamps();
 

--- a/app/sprinkles/account/src/Database/Models/User.php
+++ b/app/sprinkles/account/src/Database/Models/User.php
@@ -70,6 +70,7 @@ class User extends Model implements UserInterface
         'last_activity_id',
         'password',
         'deleted_at',
+        'newEmail',
     ];
 
     /**

--- a/app/sprinkles/account/src/Repository/VerificationRepository.php
+++ b/app/sprinkles/account/src/Repository/VerificationRepository.php
@@ -13,7 +13,7 @@ namespace UserFrosting\Sprinkle\Account\Repository;
 use UserFrosting\Sprinkle\Account\Database\Models\Interfaces\UserInterface;
 
 /**
- * Token repository class for new account verifications.
+ * Token repository class for new account verifications and email change verifications.
  *
  * @author Alex Weissman (https://alexanderweissman.com)
  *
@@ -31,7 +31,15 @@ class VerificationRepository extends TokenRepository
      */
     protected function updateUser(UserInterface $user, $args)
     {
-        $user->flag_verified = 1;
+        // If this is email update verification
+        if ( $user->flag_verified && $user->newEmail !== "" ) {
+            // Update email and remove requested
+            $user->email = $user->newEmail;
+            $user->newEmail = "";
+        } else {
+            // New user verification
+            $user->flag_verified = 1;
+        }
         // TODO: generate user activity? or do this in controller?
         $user->save();
     }

--- a/app/sprinkles/account/templates/mail/verify-new-email.html.twig
+++ b/app/sprinkles/account/templates/mail/verify-new-email.html.twig
@@ -1,0 +1,21 @@
+{% block subject %}
+    Hello {{user.first_name}} - please verify your new email for {{site.title}}
+{% endblock %}
+
+{% block body %}
+<p>Dear {{user.first_name}},
+</p>
+<p>
+You are receiving this email because you requested an email change at {{site.title}} ({{site.uri.public}}).
+</p>
+<p>
+You will need to verify your new email before change can be applied. Please follow the link below to verify your new email.
+</p>
+<p>
+<a href="{{site.uri.public}}/account/verify?token={{token}}">{{site.uri.public}}/account/verify?token={{token}}</a>
+</p>
+<p>
+With regards,<br>
+The {{site.title}} Team
+</p>
+{% endblock %}


### PR DESCRIPTION
https://huntr.dev/users/alromh87 has fixed the E-mail Verification Bypass vulnerability 🔨. alromh87 has been awarded $25 for fixing the vulnerability through the huntr bug bounty program 💵. Think you could fix a vulnerability like this?
           
Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/UserFrosting/pull/3
Vulnerability README | https://github.com/418sec/huntr/blob/staging/bounties/packagist/userfrosting/userfrosting/3/vulnerability.json

### User Comments:

### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/3-packagist-userfrosting%2Fuserfrosting

### ⚙️ Description *

UserFrosting is following strict email verification but can be bypassed by changing email in account settings.

Bypass is fixed by requiring verification before updating to new email.

### 💻 Technical Description *

Existent verification mecanism was extended to handle email address change. If mail-verification is enabled in settings, acount settings update will store newEmail as a request and send an email with link for verification, after link is open by new email owner settings will be updated to new email.

### 🐛 Proof of Concept (PoC) *

1. Setup UserFrosting repo
2. Create a user using valid email
3. Verify new acount by following verification link
4. Log in and go to My Account
5 Change the email and save
6. New email will be enabled without verification
7. Now you can login with unverified email 

![userfrostingEmailPOC0](https://user-images.githubusercontent.com/7505980/94254678-cb71cc80-ff2f-11ea-8ce2-afa68b3f5246.png)

![userfrostingEmailPOC1](https://user-images.githubusercontent.com/7505980/94254672-ca409f80-ff2f-11ea-912e-a4e044769583.png)

### 🔥 Proof of Fix (PoF) *

After fix verification email is sent to requested address and account information won't be updated untill verification is completed:

![NewEmailSent](https://user-images.githubusercontent.com/7505980/94254383-60c09100-ff2f-11ea-8904-0f32f58b6267.png)

To verify follow received link:
![NewEmailLink](https://user-images.githubusercontent.com/7505980/94254484-8483d700-ff2f-11ea-8b06-2018ce902003.png)

After verification new email can be used, account information is updated:
![NewEmailOK](https://user-images.githubusercontent.com/7505980/94254593-ad0bd100-ff2f-11ea-926a-92372c20efce.png)

### 👍 User Acceptance Testing (UAT)

e-mail can be updated using verification and application works normally