### PR TITLE
Several fixes for tests

### DIFF
--- a/app/sprinkles/core/tests/Integration/Database/DatabaseTests.php
+++ b/app/sprinkles/core/tests/Integration/Database/DatabaseTests.php
@@ -34,6 +34,8 @@ class DatabaseTests extends TestCase
         // Boot database
         $this->ci->db;
 
+        $this->schema($this->schemaName)->dropAllTables();
+
         $this->createSchema();
     }
 

--- a/app/sprinkles/core/tests/Integration/Database/Migrator/DatabaseMigratorServiceTest.php
+++ b/app/sprinkles/core/tests/Integration/Database/Migrator/DatabaseMigratorServiceTest.php
@@ -22,6 +22,8 @@ class DatabaseMigratorServiceTest extends TestCase
 {
     public function testMigratorService()
     {
+        $this->setupTestDatabase();
+
         $this->assertInstanceOf(Migrator::class, $this->ci->migrator);
     }
 }

--- a/app/sprinkles/core/tests/Integration/Database/Migrator/DatabaseMigratorServiceTest.php
+++ b/app/sprinkles/core/tests/Integration/Database/Migrator/DatabaseMigratorServiceTest.php
@@ -11,6 +11,7 @@
 namespace UserFrosting\Sprinkle\Core\Tests\Integration\Database\Migrator;
 
 use UserFrosting\Sprinkle\Core\Database\Migrator\Migrator;
+use UserFrosting\Sprinkle\Core\Tests\TestDatabase;
 use UserFrosting\Tests\TestCase;
 
 /**
@@ -20,6 +21,8 @@ use UserFrosting\Tests\TestCase;
  */
 class DatabaseMigratorServiceTest extends TestCase
 {
+    use TestDatabase;
+
     public function testMigratorService()
     {
         $this->setupTestDatabase();


### PR DESCRIPTION
At this point, all the tables from the standard migration have been created in previous tests, so tables like `users` or `roles` cannot be created again.