### PR TITLE
generateRandomToken improvement.

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Supported Versions
+
+With some exceptions, only the latest minor version (4.x), currently receive patches for security vulnerabilities. 
+The previous minor version _might_ be patched if the fix is simple. No update shall be done to previous major version (aka 3.x) or previous minor releases at this time.
+
+## Reporting a Vulnerability
+
+Please report (suspected) security vulnerabilities to the main contributors (listed below) by contacting us directly or on [Chat](https://chat.userfrosting.com). 
+If you have a fix, don't hesitate to explain or attach it. Using the issue system should be avoided for suspected security vulnerabilities.
+We'll try our best to reply in due time. If the issue is confirmed, we will see to release a patch as soon as possible depending on complexity.
+
+### Main contributors:
+- [@alexweissman](https://github.com/alexweissman)
+- [@lcharette](https://github.com/lcharette) - louis@bbqsoftwares.com
+- [@Silic0nS0ldier](https://github.com/Silic0nS0ldier)
+
+## Comments on this Policy
+
+If you have suggestions on how this process could be improved please submit a
+pull request.

--- a/app/sprinkles/account/src/Repository/TokenRepository.php
+++ b/app/sprinkles/account/src/Repository/TokenRepository.php
@@ -223,7 +223,7 @@ abstract class TokenRepository
     protected function generateRandomToken($gen = null)
     {
         do {
-            $gen = md5(uniqid(mt_rand(), false));
+            $gen = bin2hex(random_bytes(16));
         } while ($this->classMapper->getClassMapping($this->modelIdentifier)
             ::where('hash', hash($this->algorithm, $gen))
             ->first());

--- a/app/sprinkles/core/src/Util/Captcha.php
+++ b/app/sprinkles/core/src/Util/Captcha.php
@@ -68,8 +68,7 @@ class Captcha
      */
     public function generateRandomCode()
     {
-        $md5_hash = md5(rand(0, 99999));
-        $this->code = substr($md5_hash, 25, 5);
+        $this->code = substr( bin2hex( random_bytes( 3 ) ), 0, 5 );
         $enc = md5($this->code);
 
         // Store the generated captcha value to the session


### PR DESCRIPTION
The MD5 call altogether has been switched out for the hexadecimal representation of 16 CSRNG-generated bytes (the same amount at MD5 produces).
See [this](https://huntr.dev/bounties/5cc92fbb-5a63-4693-aa01-775692fb137e/).