### PR TITLE
Update uf-jqueryvalidation-config.js

### DIFF
--- a/app/sprinkles/core/assets/userfrosting/js/uf-jqueryvalidation-config.js
+++ b/app/sprinkles/core/assets/userfrosting/js/uf-jqueryvalidation-config.js
@@ -31,8 +31,14 @@ jQuery.validator.setDefaults({
     errorElement: 'p',
     errorClass: 'error-block',
     errorPlacement: function(error, element) {
-        if(element.parent('.input-group').length) {
+        if (element.hasClass('js-select2') && element.next('.select2-container').length) {
+            error.insertAfter(element.next('.select2-container'));
+        } else if (element.parent('.input-group').length) {
             error.insertAfter(element.parent());
+        } else if (element.prop('type') === 'radio' && element.parent('.radio-inline').length) {
+            error.insertAfter(element.parent().parent());
+        } else if (element.prop('type') === 'checkbox' || element.prop('type') === 'radio') {
+            error.appendTo(element.parent().parent());
         } else {
             error.insertAfter(element);
         }


### PR DESCRIPTION
Added conditions to add the JqueryValidation  message under the Select2 container. and other conditions for Radio and Checkbox.
The validation message for Select2 were showing up above the field whereas all the input fields were showing below. This fixes that.
The Radio button and Checkbox should also be fine, I have not tested all scenarios for that.