### PR TITLE
Better sprinkle discovery

### DIFF
--- a/app/sprinkles/core/src/Bakery/Test.php
+++ b/app/sprinkles/core/src/Bakery/Test.php
@@ -125,8 +125,7 @@ class Test extends BaseCommand
             exit(1);
         }
 
-        $sprinkleName = Str::studly($sprinkle);
-        $this->io->note("Executing all tests for Sprinkle '$sprinkleName'");
+        $this->io->note("Executing all tests for Sprinkle '$sprinkle'");
 
         // Check if sprinkle has phpunit.xml file
         $phpunitConfig = $sprinkleManager->getSprinklePath($sprinkle) . \UserFrosting\DS . 'phpunit.xml';
@@ -135,7 +134,7 @@ class Test extends BaseCommand
         }
 
         // Add command part
-        $testClass = $sprinkleManager->getSprinkleClassNamespace($sprinkleName) . "\Tests";
+        $testClass = $sprinkleManager->getSprinkleClassNamespace($sprinkle) . "\Tests";
         $testClass = str_replace($this->slashes, $this->slashes . $this->slashes, $testClass);
 
         return " --filter='$testClass' ";

--- a/app/sprinkles/core/src/Database/Migrator/MigrationLocator.php
+++ b/app/sprinkles/core/src/Database/Migrator/MigrationLocator.php
@@ -10,11 +10,8 @@
 
 namespace UserFrosting\Sprinkle\Core\Database\Migrator;
 
-use Illuminate\Support\Str;
 use Psr\Container\ContainerInterface;
-use UserFrosting\System\Sprinkle\SprinkleManager;
 use UserFrosting\UniformResourceLocator\Resource as ResourceInstance;
-use UserFrosting\UniformResourceLocator\ResourceLocator;
 
 /**
  * MigrationLocator Class.

--- a/app/sprinkles/core/src/Database/Seeder/Seeder.php
+++ b/app/sprinkles/core/src/Database/Seeder/Seeder.php
@@ -10,7 +10,6 @@
 
 namespace UserFrosting\Sprinkle\Core\Database\Seeder;
 
-use Illuminate\Support\Str;
 use Psr\Container\ContainerInterface;
 use UserFrosting\UniformResourceLocator\Resource as ResourceInstance;
 

--- a/app/sprinkles/core/src/Database/Seeder/Seeder.php
+++ b/app/sprinkles/core/src/Database/Seeder/Seeder.php
@@ -156,9 +156,12 @@ class Seeder
      */
     protected function getSeedDetails(ResourceInstance $file)
     {
+        /** @var \UserFrosting\System\Sprinkle\SprinkleManager */
+        $sprinkleManager = $this->ci->sprinkleManager;
+
         // Format the sprinkle name for the namespace
         $sprinkleName = $file->getLocation()->getName();
-        $sprinkleName = Str::studly($sprinkleName);
+        $sprinkleNS = $sprinkleManager->getSprinkleClassNamespace($sprinkleName);
 
         // Getting base path, name and class name
         $basePath = str_replace($file->getBasename(), '', $file->getBasePath());
@@ -168,7 +171,7 @@ class Seeder
         // Build the class name and namespace
         return [
             'name'     => $name,
-            'class'    => "\\UserFrosting\\Sprinkle\\$sprinkleName\\Database\\Seeds\\$className",
+            'class'    => "\\$sprinkleNS\\Database\\Seeds\\$className",
             'sprinkle' => $sprinkleName,
         ];
     }

--- a/app/sprinkles/core/src/ServicesProvider/ServicesProvider.php
+++ b/app/sprinkles/core/src/ServicesProvider/ServicesProvider.php
@@ -467,7 +467,7 @@ class ServicesProvider
             $migrator = new Migrator(
                 $c->db,
                 new DatabaseMigrationRepository($c->db, $c->config['migrations.repository_table']),
-                new MigrationLocator($c->locator)
+                new MigrationLocator($c)
             );
 
             // Make sure repository exist

--- a/app/sprinkles/core/tests/Integration/Database/Migrator/DatabaseMigratorIntegrationTest.php
+++ b/app/sprinkles/core/tests/Integration/Database/Migrator/DatabaseMigratorIntegrationTest.php
@@ -61,7 +61,7 @@ class DatabaseMigratorIntegrationTest extends TestCase
 
         // Get the repository and locator instances
         $this->repository = new DatabaseMigrationRepository($this->ci->db, $this->migrationTable);
-        $this->locator = new MigrationLocatorStub($this->ci->locator);
+        $this->locator = new MigrationLocatorStub($this->ci);
 
         // Get the migrator instance and setup right connection
         $this->migrator = new Migrator($this->ci->db, $this->repository, $this->locator);
@@ -190,7 +190,7 @@ class DatabaseMigratorIntegrationTest extends TestCase
     public function testWithInvalidClass()
     {
         // Change the repository so we can test with the InvalidMigrationLocatorStub
-        $locator = new InvalidMigrationLocatorStub($this->ci->locator);
+        $locator = new InvalidMigrationLocatorStub($this->ci);
         $this->migrator->setLocator($locator);
 
         // Expect a `BadClassNameException` exception
@@ -203,7 +203,7 @@ class DatabaseMigratorIntegrationTest extends TestCase
     public function testDependableMigrations()
     {
         // Change the repository so we can test with the DependableMigrationLocatorStub
-        $locator = new DependableMigrationLocatorStub($this->ci->locator);
+        $locator = new DependableMigrationLocatorStub($this->ci);
         $this->migrator->setLocator($locator);
 
         // Run up
@@ -227,7 +227,7 @@ class DatabaseMigratorIntegrationTest extends TestCase
         $this->assertTrue($this->schema->hasTable('password_resets'));
 
         // Change the repository so we can run up the `two` migrations
-        $locator = new FlightsTableMigrationLocatorStub($this->ci->locator);
+        $locator = new FlightsTableMigrationLocatorStub($this->ci);
         $this->migrator->setLocator($locator);
 
         // Run up again
@@ -243,7 +243,7 @@ class DatabaseMigratorIntegrationTest extends TestCase
     public function testUnfulfillableMigrations()
     {
         // Change the repository so we can test with the unfulfillable Stub
-        $locator = new UnfulfillableMigrationLocatorStub($this->ci->locator);
+        $locator = new UnfulfillableMigrationLocatorStub($this->ci);
         $this->migrator->setLocator($locator);
 
         // Should have an exception for unfulfilled migrations
@@ -254,7 +254,7 @@ class DatabaseMigratorIntegrationTest extends TestCase
     public function testSpecificMigrationCanBeRollback()
     {
         // Change the repository so we can test with the DependableMigrationLocatorStub
-        $locator = new DependableMigrationLocatorStub($this->ci->locator);
+        $locator = new DependableMigrationLocatorStub($this->ci);
         $this->migrator->setLocator($locator);
 
         // Run up
@@ -278,7 +278,7 @@ class DatabaseMigratorIntegrationTest extends TestCase
     public function testSpecificMigrationRollbackWithDependencies()
     {
         // Change the repository so we can test with the DependableMigrationLocatorStub
-        $locator = new DependableMigrationLocatorStub($this->ci->locator);
+        $locator = new DependableMigrationLocatorStub($this->ci);
         $this->migrator->setLocator($locator);
 
         // Run up

--- a/app/sprinkles/core/tests/Integration/Seeder/SeederTests.php
+++ b/app/sprinkles/core/tests/Integration/Seeder/SeederTests.php
@@ -13,6 +13,7 @@ namespace UserFrosting\Tests\Integration\Seeder;
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Psr\Container\ContainerInterface;
+use UserFrosting\System\Sprinkle\SprinkleManager;
 use UserFrosting\UniformResourceLocator\ResourceLocator;
 use UserFrosting\Sprinkle\Core\Database\Seeder\Seeder;
 use UserFrosting\Sprinkle\Core\Database\Seeder\SeedInterface;
@@ -42,6 +43,9 @@ class SeederTests extends TestCase
         // Register services stub
         $serviceProvider = new ServicesProviderStub();
         $serviceProvider->register($this->fakeCi);
+
+        // Use test locale data
+        $this->fakeCi->sprinkleManager = new SprinkleManager($this->fakeCi);
     }
 
     public function tearDown(): void

--- a/app/system/Bakery/Bakery.php
+++ b/app/system/Bakery/Bakery.php
@@ -10,7 +10,6 @@
 
 namespace UserFrosting\System\Bakery;
 
-use Illuminate\Support\Str;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Output\ConsoleOutput;
@@ -132,7 +131,7 @@ class Bakery
              * @var SprinkleManager
              */
             $sprinkleManager = $this->ci->sprinkleManager;
-            
+
             // Format the sprinkle name for the namespace
             $sprinkleName = $file->getLocation()->getName();
             $sprinkleNS = $sprinkleManager->getSprinkleClassNamespace($sprinkleName);

--- a/app/system/Bakery/Bakery.php
+++ b/app/system/Bakery/Bakery.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Str;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Output\ConsoleOutput;
+use UserFrosting\System\Sprinkle\SprinkleManager;
 use UserFrosting\System\UserFrosting;
 use UserFrosting\UniformResourceLocator\Resource;
 use UserFrosting\UniformResourceLocator\ResourceLocator;
@@ -127,10 +128,16 @@ class Bakery
     {
         // Process sprinkle and system commands
         if (!is_null($location = $file->getLocation())) {
+            /**
+             * @var SprinkleManager
+             */
+            $sprinkleManager = $this->ci->sprinkleManager;
+            
             // Format the sprinkle name for the namespace
             $sprinkleName = $file->getLocation()->getName();
-            $sprinkleName = Str::studly($sprinkleName);
-            $classPath = "\\UserFrosting\\Sprinkle\\$sprinkleName\\Bakery\\{$this->getClassNameFromFile($file)}";
+            $sprinkleNS = $sprinkleManager->getSprinkleClassNamespace($sprinkleName);
+
+            $classPath = "\\$sprinkleNS\\Bakery\\{$this->getClassNameFromFile($file)}";
         } else {
             $classPath = "\\UserFrosting\\System\\Bakery\\Command\\{$this->getClassNameFromFile($file)}";
         }

--- a/app/system/Sprinkle/SprinkleManager.php
+++ b/app/system/Sprinkle/SprinkleManager.php
@@ -130,22 +130,23 @@ class SprinkleManager
             $dirContent = scandir($srcPath);
             $phpFiles = array_filter(
                 $dirContent,
-                function($dirEntry) {
+                function ($dirEntry) {
                     return str_ends_with($dirEntry, '.php');
                 }
             );
             $phpFiles = array_map(
-                function($fileName) use ($srcPath) {
+                function ($fileName) use ($srcPath) {
                     return $srcPath . DIRECTORY_SEPARATOR . $fileName;
                 },
                 $phpFiles
             );
 
             $namespaces = array_unique(array_map(
-                function($file) { #extract_namespace
-                    $foundNS = NULL;
+                function ($file) { //extract_namespace
+                    $foundNS = null;
+
                     try {
-                        $handle = fopen($file, "r");
+                        $handle = fopen($file, 'r');
                         if ($handle) {
                             while (($line = fgets($handle)) !== false) {
                                 if (strpos($line, 'namespace') === 0) {
@@ -159,6 +160,7 @@ class SprinkleManager
                     } catch (Exception $e) {
                         // Silently fall back to the old studly way
                     }
+
                     return $foundNS;
                 },
                 $phpFiles

--- a/app/system/Sprinkle/SprinkleManager.php
+++ b/app/system/Sprinkle/SprinkleManager.php
@@ -115,7 +115,7 @@ class SprinkleManager
 
     /**
      * Returns the claculated sprinkle namespace.
-     * 
+     *
      * First attempts to find a php file in [sprinkleName]/src directory which contains
      * a namespace declaration. Failure to do that, fall back to the Str::studly naming
      * method. This allows namespaces to have consecutive caps:


### PR DESCRIPTION
- Modified the sprinkle manager to first attempt to find a sprinkle's namespace from the "[sprinkle]/src/[sprinkle namespace].php" file, otherwise default to the old method of using "Str::studly" which can't handle consecutive capitals (e.g. UFTweaks)
- Removed all the instances where a sprinkle name was "guessed" and replaced them using calls to the sprinkle manager instead
- Updated tests to accept the usage of the sprinkle manager