### PR TITLE
Fix missing render context arg

### DIFF
--- a/app/sprinkles/account/src/Error/Handler/AuthCompromisedExceptionHandler.php
+++ b/app/sprinkles/account/src/Error/Handler/AuthCompromisedExceptionHandler.php
@@ -33,6 +33,6 @@ class AuthCompromisedExceptionHandler extends HttpExceptionHandler
         return $this->response
             ->withStatus($this->statusCode)
             ->withHeader('Content-type', $this->contentType)
-            ->write($template->render());
+            ->write($template->render([]));
     }
 }


### PR DESCRIPTION
The context param is a mandatory arg to render(). Causes PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function Twig\Template::render(), 0 passed in ... if omitted.